### PR TITLE
Close tcp clients where they are opened

### DIFF
--- a/Telepathy/Client.cs
+++ b/Telepathy/Client.cs
@@ -40,13 +40,19 @@ namespace Telepathy
                 // but there is no server running on that ip/port
                 Logger.Log("Client: failed to connect to ip=" + ip + " port=" + port + " reason=" + exception);
 
-                // clean up properly before exiting
-                client.Close();
+
             }
             catch (Exception exception)
             {
                 // something went wrong. probably important.
                 Logger.LogError("Client Exception: " + exception);
+            }
+            finally
+            {
+                // client should aways be closed whether there is an exception or not
+                // otherwise,  if we encounter an unexpected exception,  we would 
+                // leak tcp clients
+                client.Close();
             }
         }
 

--- a/Telepathy/Common.cs
+++ b/Telepathy/Common.cs
@@ -181,7 +181,6 @@ namespace Telepathy
 
             // clean up no matter what
             stream.Close();
-            client.Close();
         }
     }
 }

--- a/Telepathy/Server.cs
+++ b/Telepathy/Server.cs
@@ -59,6 +59,8 @@ namespace Telepathy
 
                         // remove client from clients dict afterwards
                         clients.Remove(connectionId);
+
+                        client.Close();
                     });
                     thread.IsBackground = true;
                     thread.Start();


### PR DESCRIPTION
In general,  you should close resources in the same method that open them. This helps avoid leaking resources.

In addition,  close the resources in a finally clause,  so that they will still be cleaned up with unexpected exceptions.  This was a potential TcpClient leak in Client.cs