### PR TITLE
Don't send messages until the connection is established

### DIFF
--- a/LoadTest/RunClients.cs
+++ b/LoadTest/RunClients.cs
@@ -34,19 +34,22 @@ namespace Telepathy.LoadTest
             {
                 foreach (Client client in clients)
                 {
-                    // send 2 messages each time
-                    client.Send(messageBytes);
-                    client.Send(messageBytes);
-
-                    messagesSent += 2;
-                    // get new messages from queue
-                    Message msg;
-                    while (client.GetNextMessage(out msg))
+                    if (client.Connected)
                     {
-                        if (msg.eventType == EventType.Data)
+                        // send 2 messages each time
+                        client.Send(messageBytes);
+                        client.Send(messageBytes);
+
+                        messagesSent += 2;
+                        // get new messages from queue
+                        Message msg;
+                        while (client.GetNextMessage(out msg))
                         {
-                            messagesReceived++;
-                            dataReceived += msg.data.Length;
+                            if (msg.eventType == EventType.Data)
+                            {
+                                messagesReceived++;
+                                dataReceived += msg.data.Length;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
If the client is not connected,  don't send messages