### PR TITLE
Force race condition (DO NOT MERGE)

### DIFF
--- a/Telepathy/Common.cs
+++ b/Telepathy/Common.cs
@@ -1,6 +1,7 @@
 ﻿// common code used by server and client
 using System;
 using System.Net.Sockets;
+using System.Threading;
 
 namespace Telepathy
 {
@@ -186,6 +187,10 @@ namespace Telepathy
             // if we got here then either the client while loop ended, or an
             // exception happened. disconnect
             messageQueue.Enqueue(new Message(connectionId, EventType.Disconnected, null));
+
+            // this sleep forces a race condition
+            // It causes ClientKickedCleanupTest to fail reliably.
+            Thread.Sleep(1000);
 
             // clean up no matter what
             stream.Close();


### PR DESCRIPTION
This sleeps triggers the race condition reliably detected by ClientKickedCleanupTest

After the client receives the Disconnected message,  Telepathy still says the client is connected. These asserts are failing:

```c#
            Message clientDisconnectedMsg = NextMessage(client);
            Assert.That(clientDisconnectedMsg.eventType, Is.EqualTo(EventType.Disconnected));

            // was everything cleaned perfectly?
            // if Connecting or Connected is still true then we wouldn't be able
            // to reconnect otherwise
            Assert.That(client.Connecting, Is.False);
            Assert.That(client.Connected, Is.False);
```