### PR TITLE
added TryListen to Server

### DIFF
--- a/Telepathy/Server.cs
+++ b/Telepathy/Server.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
@@ -173,22 +173,52 @@ namespace Telepathy
             }
         }
 
-        // the listener thread's listen function
-        // note: no maxConnections parameter. high level API should handle that.
-        //       (Transport can't send a 'too full' message anyway)
-        void Listen(int port)
+		// attempt to start a TcpListener on the specified port
+		// if successful, the listener remains active to be used by Listen(int port)
+		bool TryListen(int port)
+		{
+			bool successful = false;
+			// absolutely must wrap with try/catch, otherwise thread
+			// exceptions are silent
+			try
+			{
+				// start listener
+				listener = new TcpListener(new IPEndPoint(IPAddress.Any, port));
+				listener.Server.NoDelay = NoDelay;
+				listener.Server.SendTimeout = SendTimeout;
+				listener.Start();
+				Logger.Log("Server: listening port=" + port);
+				successful = true;
+			}
+			catch (ThreadAbortException exception)
+			{
+				// UnityEditor causes AbortException if thread is still
+				// running when we press Play again next time. that's okay.
+				Logger.Log("Server thread aborted. That's okay. " + exception);
+			}
+			catch (SocketException exception)
+			{
+				// calling StopServer will interrupt this thread with a
+				// 'SocketException: interrupted'. that's okay.
+				Logger.Log("Server Thread stopped. That's okay. " + exception);
+			}
+			catch (Exception exception)
+			{
+				// something went wrong. probably important.
+				Logger.LogError("Server Exception: " + exception);
+			}
+			return successful;
+		}
+
+		// the listener thread's listen function
+		// note: no maxConnections parameter. high level API should handle that.
+		//       (Transport can't send a 'too full' message anyway)
+		void Listen(int port)
         {
             // absolutely must wrap with try/catch, otherwise thread
             // exceptions are silent
             try
             {
-                // start listener
-                listener = new TcpListener(new IPEndPoint(IPAddress.Any, port));
-                listener.Server.NoDelay = NoDelay;
-                listener.Server.SendTimeout = SendTimeout;
-                listener.Start();
-                Logger.Log("Server: listening port=" + port);
-
                 // keep accepting new clients
                 while (true)
                 {
@@ -260,10 +290,15 @@ namespace Telepathy
             // clear queue so we don't process anything old
             queue.Clear();
 
-            // start the listener thread
-            // (on low priority. if main thread is too busy then there is not
-            //  much value in accepting even more clients)
-            Logger.Log("Server: Start port=" + port);
+			// attempt to start the listener thread
+			// (on low priority. if main thread is too busy then there is not
+			//  much value in accepting even more clients)
+			if (!TryListen(port))
+			{
+				Logger.Log("Server: Could not start on port=" + port);
+				return false;
+			}
+			Logger.Log("Server: Start port=" + port);
             listenerThread = new Thread(() => { Listen(port); });
             listenerThread.IsBackground = true;
             listenerThread.Priority = ThreadPriority.BelowNormal;


### PR DESCRIPTION
Server Start() will now return false if the server could not start because TcpListener threw an error. Basically split Listen into TryListen and Listen where TryListen starts the listener and Listen has the while(true) loop.