### PR TITLE
Catch ThreadInterruptedException in Server.cs when closing stream/client in SendLoop

### DIFF
--- a/Telepathy/Server.cs
+++ b/Telepathy/Server.cs
@@ -116,6 +116,13 @@ namespace Telepathy
                             //  through to here when aborting. don't show an
                             //  error.)
                         }
+                        catch (ThreadInterruptedException)
+                        {
+                            // happens if receive thread interrupts send thread. don't log anything.
+                            // (we catch it in SendLoop too, but it still gets
+                            //  through to here when aborting. don't show an
+                            //  error.)
+                        }
                         catch (Exception exception)
                         {
                             Logger.LogError("Server send thread exception: " + exception);


### PR DESCRIPTION
These were getting through and logging as errors when client disconnects due to socket exceptions, trying to match functionality with ThreadAbortException.

It's possible this isn't the only scenario where a ThreadInterruptedException is thrown though? Maybe we do still want to log it?