### PR TITLE
fix: Correctly support IPv4 and IPv6 sockets

### DIFF
--- a/Telepathy.Tests/TransportTest.cs
+++ b/Telepathy.Tests/TransportTest.cs
@@ -32,7 +32,7 @@ namespace Telepathy.Tests
         public void DisconnectImmediateTest()
         {
             Client client = new Client();
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // I should be able to disconnect right away
             // if connection was pending,  it should just cancel
@@ -48,7 +48,7 @@ namespace Telepathy.Tests
             Client client = new Client();
             for (int i = 0; i < 1000; i++)
             {
-                client.Connect("127.0.0.1", port);
+                client.Connect("localhost", port);
                 Assert.That(client.Connecting || client.Connected, Is.True);
                 client.Disconnect();
                 Assert.That(client.Connected, Is.False);
@@ -62,7 +62,7 @@ namespace Telepathy.Tests
             // BeginSend can't be called again after previous one finished. try
             // to trigger that case.
             Client client = new Client();
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // wait for successful connection
             Message connectMsg = NextMessage(client);
@@ -84,7 +84,7 @@ namespace Telepathy.Tests
         public void ReconnectTest()
         {
             Client client = new Client();
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // wait for successful connection
             Message connectMsg = NextMessage(client);
@@ -95,7 +95,7 @@ namespace Telepathy.Tests
             Assert.That(client.Connecting, Is.False);
 
             // connecting should flush message queue  right?
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
             // wait for successful connection
             connectMsg = NextMessage(client);
             Assert.That(connectMsg.eventType, Is.EqualTo(EventType.Connected));
@@ -110,7 +110,7 @@ namespace Telepathy.Tests
             Encoding utf8 = Encoding.UTF8;
             Client client = new Client();
 
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // we should first receive a connected message
             Message connectMsg = NextMessage(server);
@@ -135,7 +135,7 @@ namespace Telepathy.Tests
             Encoding utf8 = Encoding.UTF8;
             Client client = new Client();
 
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // we  should first receive a connected message
             Message serverConnectMsg = NextMessage(server);
@@ -165,7 +165,7 @@ namespace Telepathy.Tests
         {
             Client client = new Client();
 
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // we  should first receive a connected message
             Message serverConnectMsg = NextMessage(server);
@@ -180,7 +180,7 @@ namespace Telepathy.Tests
         {
             Client client = new Client();
 
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // read connected message on client
             Message clientConnectedMsg = NextMessage(client);
@@ -210,7 +210,7 @@ namespace Telepathy.Tests
         {
             // connect a client
             Client client = new Client();
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // get server's connect message
             Message serverConnectMsg = NextMessage(server);
@@ -218,7 +218,7 @@ namespace Telepathy.Tests
 
             // get server's connection info for that client
             string address = server.GetClientAddress(serverConnectMsg.connectionId);
-            Assert.That(address == "127.0.0.1" || address == "::ffff:127.0.0.1");
+            Assert.That(address == "localhost" || address == "::ffff:127.0.0.1" || address == "::1");
 
             client.Disconnect();
         }
@@ -243,7 +243,7 @@ namespace Telepathy.Tests
         {
             // connect a client
             Client client = new Client();
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // we should first receive a connected message
             Message serverConnectMsg = NextMessage(server);
@@ -266,7 +266,7 @@ namespace Telepathy.Tests
         {
             // connect a client
             Client client = new Client();
-            client.Connect("127.0.0.1", port);
+            client.Connect("localhost", port);
 
             // we should first receive a connected message
             Message serverConnectMsg = NextMessage(server);

--- a/Telepathy/Client.cs
+++ b/Telepathy/Client.cs
@@ -105,14 +105,13 @@ namespace Telepathy
             // We are connecting from now until Connect succeeds or fails
             _Connecting = true;
 
-            // IPAddress.Parse() can't parse "localhost"
-            if (ip.ToLower() == "localhost")
-                ip = "127.0.0.1";
-
             // TcpClient can only be used once. need to create a new one each
             // time.
-            // (IPAddress.Parse.AddressFamily to support both IPv4 and IPv6)
-            client = new TcpClient(IPAddress.Parse(ip).AddressFamily);
+            // initialize it with InterNetworkV6 and dual mode to support
+            // both IPv6 and IPv4
+            client = new TcpClient(AddressFamily.InterNetworkV6);
+            // works with IPv6 and IPv4
+            client.Client.DualMode = true;
             client.NoDelay = NoDelay;
             client.SendTimeout = SendTimeout;
 

--- a/Telepathy/Server.cs
+++ b/Telepathy/Server.cs
@@ -76,10 +76,9 @@ namespace Telepathy
             // exceptions are silent
             try
             {
-                // start listener on any IPv4 and IPv6 address.
+                // start listener on all IPv4 and IPv6 address.
                 // (using IPAddress.IPAny would be IPv4 only)
-                listener = new TcpListener(IPAddress.IPv6Any, port);
-                listener.Server.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false); // listen to IPv4 AND IPv6
+                listener = TcpListener.Create(port);
                 listener.Server.NoDelay = NoDelay;
                 listener.Server.SendTimeout = SendTimeout;
                 listener.Start();


### PR DESCRIPTION
Previous "localhost"  fix is a hack.

This is the way to support both dual IPv6 and IPv4 sockets according to microsoft:
https://devblogs.microsoft.com/aspnet/dual-mode-sockets-never-create-an-ipv4-socket-again/