### PR TITLE
Reset Counter in Stop

### DIFF
--- a/Telepathy/Server.cs
+++ b/Telepathy/Server.cs
@@ -233,6 +233,10 @@ namespace Telepathy
 
             // clear clients list
             clients.Clear();
+
+            // reset the counter in case we start up again so
+            // clients get connection ID's starting from 1
+            counter = 0;
         }
 
         // send message to client using socket connection.


### PR DESCRIPTION
If server / host is stopped and restarted without actually restarting the app, this will reset the counter to zero so clients get connection ID's starting from 1 again.