### PR TITLE
Use null propagation on client.close()

### DIFF
--- a/Telepathy/Client.cs
+++ b/Telepathy/Client.cs
@@ -99,7 +99,7 @@ namespace Telepathy
             // if we got here then we are done. ReceiveLoop cleans up already,
             // but we may never get there if connect fails. so let's clean up
             // here too.
-            client.Close();
+            client?.Close();
         }
 
         public void Connect(string ip, int port)


### PR DESCRIPTION
Not sure if i'm doing something wrong, I really just followed the README so I have a very basic server, and everythig works great! Except when I click "play" in unity to stop the game within the editor. I get this error in the console:

```
NullReferenceException: Object reference not set to an instance of an object
Telepathy.Client.ReceiveThreadFunction (System.String ip, System.Int32 port) (at Assets/Scripts/Telepathy/Client.cs:101)
Telepathy.Client+<>c__DisplayClass11_0.<Connect>b__0 () (at Assets/Scripts/Telepathy/Client.cs:143)
System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) (at <ad04dee02e7e4a85a1299c7ee81c79f6>:0)
System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) (at <ad04dee02e7e4a85a1299c7ee81c79f6>:0)
System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) (at <ad04dee02e7e4a85a1299c7ee81c79f6>:0)
System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) (at <ad04dee02e7e4a85a1299c7ee81c79f6>:0)
System.Threading.ThreadHelper.ThreadStart () (at <ad04dee02e7e4a85a1299c7ee81c79f6>:0)
UnityEngine.UnhandledExceptionHandler:<RegisterUECatcher>m__0(Object, UnhandledExceptionEventArgs)
```