### PR TITLE
change null check

### DIFF
--- a/Telepathy/Client.cs
+++ b/Telepathy/Client.cs
@@ -99,7 +99,7 @@ namespace Telepathy
             // if we got here then we are done. ReceiveLoop cleans up already,
             // but we may never get there if connect fails. so let's clean up
             // here too.
-            client?.Close();
+            if (client != null) client.Close();
         }
 
         public void Connect(string ip, int port)


### PR DESCRIPTION
I've had a number of people in discord report this error, and the proposed change eliminates it:
```
NullReferenceException: Object reference not set to an instance of an object
Telepathy.Client.ReceiveThreadFunction (System.String ip, System.Int32 port) (at Assets/Mirror/Runtime/Transport/Telepathy/Client.cs:102)
Telepathy.Client+<>c__DisplayClass11_0.<Connect>b__0 () (at Assets/Mirror/Runtime/Transport/Telepathy/Client.cs:144)
System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) (at <599589bf4ce248909b8a14cbe4a2034e>:0)
System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) (at <599589bf4ce248909b8a14cbe4a2034e>:0)
System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) (at <599589bf4ce248909b8a14cbe4a2034e>:0)
System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) (at <599589bf4ce248909b8a14cbe4a2034e>:0)
System.Threading.ThreadHelper.ThreadStart () (at <599589bf4ce248909b8a14cbe4a2034e>:0)
UnityEngine.UnhandledExceptionHandler:<RegisterUECatcher>m__0(Object, UnhandledExceptionEventArgs)
```