### PR TITLE
adding helper function to get random unused port

### DIFF
--- a/Telepathy/Utils.cs
+++ b/Telepathy/Utils.cs
@@ -40,5 +40,14 @@ namespace Telepathy
                 (bytes[2] << 8) |
                 bytes[3];
         }
+
+        public static int GetRandomUnusedPort()
+        {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Any, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
     }
 }


### PR DESCRIPTION
**source:** 
https://stackoverflow.com/questions/223063/how-can-i-create-an-httplistener-class-on-a-random-port-in-c

I feel this would be nice to get things going quickly, especially when doing dev work. Dev'ing in different ports is always better than hardcoding something. Nothing big in terms of investment so feel free to refuse. 

Good light weight lib and hoping to contribute more substantial stuff :) 