### PR TITLE
adding warning to client connect

### DIFF
--- a/Telepathy/Client.cs
+++ b/Telepathy/Client.cs
@@ -112,7 +112,11 @@ namespace Telepathy
         public void Connect(string ip, int port)
         {
             // not if already started
-            if (Connecting || Connected) return;
+            if (Connecting || Connected)
+            {
+                Logger.LogWarning("Telepathy Client can not create connection because an existing connection is connecting or connected");
+                return;
+            }
 
             // We are connecting from now until Connect succeeds or fails
             _Connecting = true;


### PR DESCRIPTION
If someone calls NetworkClient.Connect(networkAddress); or Transport.activeTransport.ClientConnect(address); while an existing client is connecting/connected the user has no way of knowing that the new connect fails.

This can be a problem if a user tries to connect to multiple servers quickly before first request times out.

Copy of https://github.com/vis2k/Mirror/pull/1874