### PR TITLE
Fix for disconnect bug

### DIFF
--- a/Telepathy/Client.cs
+++ b/Telepathy/Client.cs
@@ -112,7 +112,11 @@ namespace Telepathy
         public void Connect(string ip, int port)
         {
             // not if already started
-            if (Connecting || Connected) return;
+            if (Connecting || Connected)
+            {
+                Logger.LogWarning("Telepathy Client can not create connection because an existing connection is connecting or connected");
+                return;
+            }
 
             // We are connecting from now until Connect succeeds or fails
             _Connecting = true;


### PR DESCRIPTION
Duplicate of PR from Mirror https://github.com/vis2k/Mirror/pull/1877

Connecting, disconnecting and trying to connect to a different connection causes both connections to close when the first one fails to connect.

Adding a class to keep track of the current TpcClient and threads. If the connection is closed while Connect is still blocking the thread then SocketException will be throw before ThreadInterruptedException is caught.



Also includes warning from https://github.com/vis2k/Telepathy/pull/90