### PR TITLE
Fixed ObjectDisposedException on disconnect

### DIFF
--- a/Telepathy/NetworkStreamExtensions.cs
+++ b/Telepathy/NetworkStreamExtensions.cs
@@ -16,7 +16,7 @@ namespace Telepathy
             {
                 return stream.Read(buffer, offset, size);
             }
-            catch (IOException)
+            catch (System.Exception e) when (e is IOException || e is System.ObjectDisposedException)
             {
                 return 0;
             }


### PR DESCRIPTION
On calling `Client.Disconnect()`, sometimes a `System.ObjectDisposedException` is thrown by `NetworkStream.Read`, and thus, `NetworkStreamExtensions.ReadSafely`. 

This happens because the `NetworkStream` has been disposed but is being `Read` from, and is throwing the `ObjectDisposedException` instead of the `IOException` that is mentioned in this comment:
```
// .Read returns '0' if remote closed the connection but throws an
// IOException if we voluntarily closed our own connection.
```